### PR TITLE
fixed formatting Number Sets to needed dynamodb wire format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.node
+node_modules/
+npm-debug.log

--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -5,7 +5,7 @@
  *
  * @name DynamoDBDatatype
  */
-function DynamoDBDatatype() {    
+function DynamoDBDatatype() {
     var AWS = typeof(window) === "undefined" ? require("aws-sdk") : window.AWS;
     var Uint8ArrayError = "Uint8Array can only be used for Binary in Browser.";
     var ScalarDatatypeError = "Unrecognized Scalar Datatype to be formatted.";
@@ -14,7 +14,7 @@ function DynamoDBDatatype() {
     var StrConversionError = "Need to pass in string primitive to be converted to binary.";
 
     function isScalarType(dataType) {
-        
+
         var type = typeof(dataType);
         return  type === "number"  ||
                 type === "string"  ||
@@ -23,46 +23,56 @@ function DynamoDBDatatype() {
                 dataType instanceof(AWS.util.Buffer) ||
                 dataType === null;
     }
-    
+
     function isSetType(dataType) {
         return dataType.datatype === "SS" ||
                 dataType.datatype === "NS" ||
                 dataType.datatype === "BS";
     }
-    
+
     function isRecursiveType(dataType) {
-        
+
         return Array.isArray(dataType) ||
                 typeof(dataType) === "object";
     }
-    
+
+    function formatSetValues(datatype, values) {
+        if(datatype === "NS") {
+            return values.map(function (n) {
+                return n.toString();
+            });
+        } else {
+          return values;
+        }
+    };
+
     function formatRecursiveType(dataType) {
-        
+
         var recursiveDoc = {};
-    
+
         var value = {};
         var type = "M";
         if (Array.isArray(dataType)) {
             value = [];
             type = "L";
         }
-    
+
         for (var key in dataType) {
             value[key] = this.formatDataType(dataType[key]);
         }
-    
+
         recursiveDoc[type] = value;
-        return recursiveDoc; 
+        return recursiveDoc;
     }
-    
+
     /** @throws Uint8ArrayError, ScalarDatatypeError
      *  @private */
     function formatScalarType(dataType) {
-        
+
         if (dataType == null) {
             return { "NULL" : true };
         }
-    
+
         var type = typeof(dataType);
         if (type === "string") {
             return { "S" : dataType };
@@ -82,10 +92,10 @@ function DynamoDBDatatype() {
             throw new Error(ScalarDatatypeError);
         }
     }
-    
+
     /**
      * Formats Javascript datatypes into DynamoDB wire format.
-     * 
+     *
      * @name formatDataType
      * @function
      * @memberOf DynamoDBDatatype#
@@ -94,17 +104,17 @@ function DynamoDBDatatype() {
      * @throws GeneralDatatypeError
      */
     this.formatDataType = function(dataType) {
-        
+
         if (isScalarType(dataType)) {
             return formatScalarType(dataType);
         } else if (isSetType(dataType)) {
             return dataType.format();
         } else if (isRecursiveType(dataType)) {
-            return formatRecursiveType.call(this, dataType);            
+            return formatRecursiveType.call(this, dataType);
         }  else {
             throw new Error(GeneralDatatypeError);
         }
-        
+
     };
 
     function str2Bin(value) {
@@ -161,10 +171,10 @@ function DynamoDBDatatype() {
     this.binToStr = function(value) {
         return bin2Str.call(this, value);
     };
-    
+
     /**
      * Utility to create the DynamoDB Set Datatype.
-     * 
+     *
      * @function createSet
      * @memberOf DynamoDBDatatype#
      * @param {array} set An array that contains elements of the same typed as defined by {type}.
@@ -176,11 +186,11 @@ function DynamoDBDatatype() {
         if (type !== "N" && type !== "S" && type !== "B") {
             throw new Error(this.type + " is an invalid type for Set");
         }
-    
+
         var setObj = function Set(set, type) {
             this.datatype = type + "S";
             this.contents = {};
-    
+
             this.add = function(value) {
                 if (this.datatype === "SS" && typeof(value) === "string") {
                     this.contents[value] = value;
@@ -198,18 +208,18 @@ function DynamoDBDatatype() {
                     throw new Error("Inconsistent in this " + this.type + " Set");
                 }
             };
-        
+
             this.contains = function(content) {
                 var value = content;
                 if (content instanceof AWS.util.Buffer || content instanceof(Uint8Array)) {
                     value = bin2Str(content);
-                } 
+                }
                 if (this.contents[value] === undefined) {
                     return false;
                 }
                 return true;
             };
-    
+
             this.remove = function(content) {
                 var value = content;
                 if (content instanceof AWS.util.Buffer || content instanceof(Uint8Array)) {
@@ -217,41 +227,41 @@ function DynamoDBDatatype() {
                 }
                 delete this.contents[value];
             };
-    
+
             this.toArray = function() {
                 var keys = Object.keys(this.contents);
                 var arr = [];
-    
+
                 for (var keyIndex in keys) {
                     var key = keys[keyIndex];
                     if (this.contents.hasOwnProperty(key)) {
                         arr.push(this.contents[key]);
                     }
                 }
-    
+
                 return arr;
             };
-    
+
             this.format = function() {
-                var values = this.toArray(); 
+                var values = this.toArray();
                 var result = {};
-                result[this.datatype] = values;
+                result[this.datatype] = formatSetValues(this.datatype, values);
                 return result;
             };
-    
+
             if (set) {
                 for (var index in set) {
                     this.add(set[index]);
                 }
             }
         };
-    
+
         return new setObj(set, type);
     };
 
     /**
      * Formats DynamoDB wire format into javascript datatypes.
-     * 
+     *
      * @name formatWireType
      * @function
      * @memberOf DynamoDBDatatype#
@@ -288,7 +298,7 @@ function DynamoDBDatatype() {
                 throw "Service returned unrecognized datatype " + key;
         }
     }
-} 
+}
 
 if (typeof(module) !== "undefined") {
     var exports = module.exports = {};

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "description": "DynamoDB Document SDK for Javascript",
   "version": "1.0.0",
   "author": {
-      "name": "Amazon Web Services",
-      "email": "",
-      "url": "http://aws.amazon.com/"
+    "name": "Amazon Web Services",
+    "email": "",
+    "url": "http://aws.amazon.com/"
   },
   "homepage": "https://github.com/awslabs/dynamodb-document-js-sdk",
   "contributors": [
@@ -13,28 +13,37 @@
     "Loren Segal <lsegal@amazon.com>"
   ],
   "devDependencies": {
-    "uglify-js": "2.*",
-    "mocha": "^1.21.0"
+    "chai": "^1.10.0",
+    "mocha": "^1.21.0",
+    "uglify-js": "2.*"
   },
   "dependencies": {
     "aws-sdk": "^2.0.19"
   },
   "main": "lib/dynamodb-doc.js",
   "directories": {
-      "lib": "lib"
+    "lib": "lib"
   },
   "engines": {
-      "node": ">= 0.8.0"
+    "node": ">= 0.8.0"
   },
   "repository": {
-      "type" : "git",
-      "url": "git://github.com/awslabs/dynamodb-document-js-sdk"
+    "type": "git",
+    "url": "git://github.com/awslabs/dynamodb-document-js-sdk"
   },
-  "licenses": [{
+  "licenses": [
+    {
       "type": "Apache 2.0",
       "url": "https://github.com/awslabs/dynamodb-document-js-sdk/blob/master/LICENSE.txt"
-  }],
-  "keywords": ["dynamodb", "document", "js", "javascript", "sdk"],
+    }
+  ],
+  "keywords": [
+    "dynamodb",
+    "document",
+    "js",
+    "javascript",
+    "sdk"
+  ],
   "scripts": {
     "test": "mocha test"
   }

--- a/test/datatypes.js
+++ b/test/datatypes.js
@@ -1,5 +1,6 @@
 "use strict";
 var assert = require("assert");
+var expect = require("chai").expect;
 var datatypes = require("../lib/datatypes").DynamoDBDatatype;
 var t = new datatypes();
 
@@ -49,7 +50,7 @@ describe("Testing DataTypes", function() {
             assert(testNumSet, "Did not successfully create a NumSet.");
         });
 
-        it("as a StrSet.", function() {
+        it("as a BinSet.", function() {
             testBinSet = t.createSet([new Buffer("10"), new Buffer("01")], "B");
             assert(testBinSet, "Did not successfully create a BinSet.");
         });
@@ -66,7 +67,7 @@ describe("Testing DataTypes", function() {
                     var modified_length = testStrSet.toArray().length;
                     assert.equal(initial_length, modified_length);
                 });
-                
+
                 it("with unique value.", function() {
                     var initial_length = testStrSet.toArray().length;
                     testStrSet.add("d");
@@ -95,4 +96,22 @@ describe("Testing DataTypes", function() {
 
     });
 
+    describe('Testing createSet #format', function () {
+        it("as a StringSet.", function() {
+            var stringSet = t.createSet(["a", "b", "c"], "S");
+            // nodejs built in assert deep equals does not do strict equality
+            expect(stringSet.format()).to.eql({SS : ["a", "b", "c"]});
+        });
+
+        it("as a NumSet.", function() {
+            var numberSet = t.createSet([1, 2, 3], "N");
+            // nodejs built in assert deep equals does not do strict equality
+            expect(numberSet.format()).to.eql({NS : ["1", "2", "3"]});
+        });
+
+        it("as a BinSet.", function() {
+            var binSet = t.createSet([new Buffer("hello"), new Buffer("world")], "B");
+            expect(binSet.format()).to.eql({BS : [new Buffer("hello"), new Buffer("world")]});
+        });
+    });
 });


### PR DESCRIPTION
This Fixes #7

Sorry for the messy diff, my editor automatically got rid of empty spaces.  I also installed chai as a new dev dependency because node's built in deepEqual does not do strict equality of values. Thus when I was testing the different between {NS : [1,2,3]} it would not throw an exception when matching {NS : ["1", "2", "3"]}. 
