### PR TITLE
Address type error in DynamoDBDatatype.formatWireType

### DIFF
--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -282,6 +282,8 @@ function DynamoDBDatatype() {
             case "L":
             case "M":
                 for (var keyIndex in value) {
+                    if (!value.hasOwnProperty(keyIndex)) continue;
+
                     var subValue = value[keyIndex];
                     var subKey = Object.keys(subValue)[0];
                     value[keyIndex] = this.formatWireType(subKey, subValue[subKey]);

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -398,16 +398,27 @@ describe("Testing Format Output", function() {
         var mlResponseData = {};
         mlResponseData.Item = {"UserId":
                                  "raymolin",
-                                "Age":
-                                  21};
+                               "Age":
+                                  21,
+                               "Friends":
+                                  { "Gaming":
+                                      ["Abe", "Ally"]}};
 
         beforeEach(function() {
             response.data = {};
+            Array.prototype.notAnElement = function() {};
             response.data.Item = {"UserId": 
                                     {"S": "raymolin"},
                                   "Age":
-                                    {"N": "21"}};
+                                    {"N": "21"},
+                                  "Friends":
+                                    {"M": { "Gaming":
+                                              {"L": [{"S": "Abe"}, {"S": "Ally"}]}}}};
 
+        });
+
+        afterEach(function() {
+          delete Array.prototype.notAnElement;
         });
 
         it("with a simple response", function() {


### PR DESCRIPTION
- when calling client.getItem
- when Item has an Array
- when call is made in context of Ember framework (or any context that extends Array.protoype)

I encountered when giving this lib a quick try within the context of a simple Ember app using default settings (i.e. not disabling the prototype extensions).  

Granted, this concern seems to be the responsibility of the library caller, but to the extent you want to support this case, the given solution here would work (as indicated by the included Mocha test).  To spread adoption, I assume you might want to remove any possible barrier (even silly ones not of your own making).  It would also help me to avoid the need to disable the Ember default behavior.

Another solution would be to break out `L` and `M` into separate cases in `DynamoDBDatatype.formatWireType` and iterate over the array case using 

```
for (var i=0; i < value.length; i++) {...}
```

For more information:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Iterating_over_own_properties_only
- http://emberjs.com/guides/configuring-ember/disabling-prototype-extensions/
