### PR TITLE
[Condition] use variable arguments for IN operation.

### DIFF
--- a/lib/condition.js
+++ b/lib/condition.js
@@ -5,42 +5,41 @@
  *
  * @param {string} key The attribute name being conditioned on.
  * @param {string} operator The operator in the conditional clause. (See aws sdk docs for full list of operators)
- * @param val1 Potential first element in what would be the AttributeValueList
- * @param val2 Potential second element in what would be the AttributeValueList
+ * @param val<n> Potential <n>nd element in what would be the AttributeValueList (optional)
  * @return {Condition} Condition for your DynamoDB request.
  */
-function DynamoDBCondition(key, operator, val1, val2) {
+function DynamoDBCondition(key, operator) { /* and variable arguments. */
     var datatypes = typeof(window) === "undefined" ? require("./datatypes").DynamoDBDatatype
                 : window.DynamoDBDatatype;
 
     var t = new datatypes();
 
-    var CondObj = function Condition(key, operator, val1, val2) {
+    var args = Array.prototype.slice.call(arguments, 2);
+
+    var CondObj = function Condition(key, operator, args) {
             this.key = key;
             this.operator = operator;
-            this.val1 = val1;
-            this.val2 = val2;
-        
+            this.args = args;
+
             this.format = function() {
                 var formatted = {};
-        
                 var attrValueList = [];
-                if (this.val1 !== undefined) {
-                    attrValueList.push(t.formatDataType(this.val1)); 
-                }
-                if (this.val2 !== undefined) {
-                    attrValueList.push(t.formatDataType(this.val2));
+
+                for (var i=0; i<this.args.length; i++) {
+                    if (this.args[i] !== undefined) {
+                        attrValueList.push(t.formatDataType(this.args[i]));
+                    }
                 }
                 if (attrValueList.length > 0) {
                     formatted.AttributeValueList = attrValueList;
                 }
                 formatted.ComparisonOperator = this.operator;
-        
+
                 return formatted;
             };
     };
 
-    var cond = new CondObj(key, operator, val1, val2);
+    var cond = new CondObj(key, operator, args);
     cond.prototype = Object.create(Object.prototype);
     cond.prototype.instanceOf  = "DynamoDBConditionObject";
 

--- a/lib/condition.js
+++ b/lib/condition.js
@@ -21,6 +21,10 @@ function DynamoDBCondition(key, operator) { /* and variable arguments. */
             this.operator = operator;
             this.args = args;
 
+            // for comatibility
+            this.val1 = args[0];
+            this.val2 = args[1];
+
             this.format = function() {
                 var formatted = {};
                 var attrValueList = [];

--- a/lib/dynamodb-doc.js
+++ b/lib/dynamodb-doc.js
@@ -52,11 +52,11 @@ function DynamoDB(dynamoDB) {
     * @param {string} key The attribute name being conditioned.
     * @param {string} operator The operator in the conditional clause. (See lower level docs for full list of operators)
     * @param val1 Potential first element in what would be the AttributeValueList
-    * @param val2 Potential second element in what would be the AttributeValueList
+    * @param val* Potential *nd element in what would be the AttributeValueList (optional)
     * @return {Condition} Condition for your DynamoDB request.
     */
-    service.__proto__.Condition = function(key, operator, val1, val2) {
-        return condition(key, operator, val1, val2);
+    service.__proto__.Condition = function(/*key, operator, val1, val2, ...*/) {
+        return condition.apply(this, arguments);
     };
 
     /**


### PR DESCRIPTION
On many "IN" operator usecases, AttributeValueList have many items.
but, Condition() API have only two variables `val1` and `val2`, it is inconvenience.

This patch resolve that problem by variable arguments.
It keeping backward compatibility.