### PR TITLE
Added files property to keep footprint as small as possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   ],
   "scripts": {
     "test": "mocha test"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
Resolved #45. This will make sure only the `lib` directory is installed when using `npm install dynamodb-doc`.