### PR TITLE
Add new operator to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Alternatively if you already have the existing DynamoDB Client, you can pass it 
 
 ``` javascript
 // assumes AWS.config is set up already
-var awsClient = AWS.DynamoDB();
+var awsClient = new AWS.DynamoDB();
 var docClient = new DOC.DynamoDB(awsClient);
 ```
 


### PR DESCRIPTION
*Description of changes:*
When copying what there is in the docs, I'm getting the following error: 
```
      throw AWS.util.error(new Error(),
      ^

Error: Service must be constructed with `new' operator
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
